### PR TITLE
Preserve Portable PDB embedded in the DLL. Update the dependencies to the latest.

### DIFF
--- a/InjectModuleInitializer.csproj
+++ b/InjectModuleInitializer.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>EinarEgilsson.Utilities.InjectModuleInitializer</RootNamespace>
     <AssemblyName>InjectModuleInitializer</AssemblyName>
-    <TargetFramework>net35</TargetFramework>
+    <TargetFramework>net40</TargetFramework>
     <DefaultItemExcludes>*.binlog;Test\**\*.*;nuget\**\*.*</DefaultItemExcludes>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -26,8 +26,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.0" PrivateAssets="all" />
-    <PackageReference Include="GitInfo" Version="2.0.10" PrivateAssets="all" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.4" PrivateAssets="all" />
+    <PackageReference Include="GitInfo" Version="2.2.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Injector.cs
+++ b/Injector.cs
@@ -88,12 +88,16 @@ namespace EinarEgilsson.Utilities.InjectModuleInitializer
         private void WriteAssembly(string assemblyFile, string keyfile)
         {
             Debug.Assert(Assembly != null);
-            var writeParams = new WriterParameters();
+            var writeParams = new WriterParameters()
+                {
+                    WriteSymbols = true, // this takes care of embedded Portable PDB
+                };
+
             if (PdbFile(assemblyFile) != null)
             {
-                writeParams.WriteSymbols = true;
                 writeParams.SymbolWriterProvider = new PdbWriterProvider();
             }
+
             if (keyfile != null)
             {
                 writeParams.StrongNameKeyPair = new StrongNameKeyPair(File.ReadAllBytes(keyfile));
@@ -109,16 +113,17 @@ namespace EinarEgilsson.Utilities.InjectModuleInitializer
             resolver.AddSearchDirectory(Path.GetDirectoryName(assemblyFile));
 
             var readParams = new ReaderParameters(ReadingMode.Immediate)
-            {
-                AssemblyResolver = resolver,
-                InMemory = true
-            };
-            
+                {
+                    AssemblyResolver = resolver,
+                    InMemory = true,
+                    ReadSymbols = true, // this takes care of embedded Portable PDB
+                };
+
             if (PdbFile(assemblyFile) != null)
             {
-                readParams.ReadSymbols = true;
                 readParams.SymbolReaderProvider = new PdbReaderProvider();
             }
+
             Assembly = AssemblyDefinition.ReadAssembly(assemblyFile, readParams);
         }
 


### PR DESCRIPTION
Copied from #24